### PR TITLE
Fix cmake errors for cross compile on other target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,13 @@
+
+if (NOT DEFINED TARGET_TOOLCHAIN)
+    SET (TARGET_TOOLCHAIN "mcc-linux-x86")
+endif()
+set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_LIST_DIR}/cmake/toolchains/${TARGET_TOOLCHAIN}.cmake")
+#message ("CMAKE_TOOLCHAIN_FILE ${CMAKE_TOOLCHAIN_FILE}")
+
 project ("mbed-edge" C)
 cmake_minimum_required (VERSION 2.8)
+
 
 SET (EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 

--- a/cmake/edge_configure.cmake
+++ b/cmake/edge_configure.cmake
@@ -76,10 +76,6 @@ if (NOT DEFINED TARGET_DEVICE)
 endif()
 include ("cmake/targets/${TARGET_DEVICE}.cmake")
 
-if (NOT DEFINED TARGET_TOOLCHAIN)
-    SET (TARGET_TOOLCHAIN "mcc-linux-x86")
-endif()
-include ("cmake/toolchains/${TARGET_TOOLCHAIN}.cmake")
 
 if (${FIRMWARE_UPDATE})
   MESSAGE ("Enabling firmware update for Mbed Edge")


### PR DESCRIPTION
# Mbed Edge pull request

`
Please fill this pull request template to describe your pull request.
If it introduces API breaks please describe it in detail.
`

## Description

`submitter: Please add a description of your PR here.`
When doing the cross compie for 3rd party platform. It will always fail at the libevent Pre-Check (CHECK_INCLUDE_FILE).
From the log, we see the cross toolchain setting wasn't effect for the libraries.

After some debugging, we found the toolChain setting should be moved to the beginning of the whole project.
Else the 3rd party libraries (libevent) may still use host's cmake system which leads to fail.

## Test instructions

`Submitter: Please add instructions to test your PR here.`

`If your pull request is a fix for a defect please write instructions
to reproduce the defect.`

## Check list

### API change(s)

 - [x] Not applicable.
 - [ ] API is backwards compatible.
 - [ ] API documentation is updated.

### Example applications updated

 - [x] Not applicable.
 

