### PR TITLE
switch entropy source for x86 targets

### DIFF
--- a/lib/mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/Linux/Board_Specific/TARGET_x86_x64/pal_plat_x86_x64.c
+++ b/lib/mbed-cloud-client/mbed-client-pal/Source/Port/Reference-Impl/OS_Specific/Linux/Board_Specific/TARGET_x86_x64/pal_plat_x86_x64.c
@@ -19,5 +19,5 @@
 
 palStatus_t pal_plat_getRandomBufferFromHW(uint8_t *randomBuf, size_t bufSizeBytes, size_t* actualRandomSizeBytes)
 {
-    return pal_plat_osEntropyRead("/dev/random", randomBuf, bufSizeBytes, actualRandomSizeBytes);
+    return pal_plat_osEntropyRead("/dev/urandom", randomBuf, bufSizeBytes, actualRandomSizeBytes);
 }


### PR DESCRIPTION
# Mbed Edge pull request

## Description

Switch entropy source from '/dev/random' to '/dev/urandom' to improve startup performance for x86 targets.
 /dev/random is blocking and causes a LONG delay for edge-core startup.  /dev/urandom is not.

Info on random vs urandom -> https://www.2uo.de/myths-about-urandom/
 
## Test instructions
build edge core and observe much faster RN generation / edge-core startup.
 

