### PR TITLE
Added missing flag for command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ $ apt install build-essential cmake git doxygen graphviz
 Fetch the Git submodules that are direct dependencies for Edge.
 ```
 $ git submodule init
-$ git submodule update
+$ git submodule update --recursive
 ```
 
 ## Configuring Edge build


### PR DESCRIPTION
# Mbed Edge pull request

`--recursive` was missing from 'git submodule update'

## Description

Simple README.md update to fix an issue found in https://github.com/ARMmbed/mbed-edge/issues/17

## Test instructions

Manually run updated doc command.

## Check list

### API change(s)

 - [x] Not applicable.
 - [ ] API is backwards compatible.
 - [ ] API documentation is updated.

### Example applications updated

 - [x] Not applicable.
 

