### PR TITLE
Call a script on factory reset

### DIFF
--- a/edge-core/edge_server_customer_code.c
+++ b/edge-core/edge_server_customer_code.c
@@ -21,6 +21,7 @@
 #include "edge-client/edge_client.h"
 #include "mbed-trace/mbed_trace.h"
 #include "edge-core/edge_server_customer_code.h"
+#include <stdlib.h>
 #define TRACE_GROUP "escstmr"
 
 bool edgeserver_execute_rfs_customer_code(edgeclient_request_context_t *request_ctx)
@@ -29,6 +30,10 @@ bool edgeserver_execute_rfs_customer_code(edgeclient_request_context_t *request_
             request_ctx->object_id,
             request_ctx->object_instance_id,
             request_ctx->resource_id);
+    
+    // Clear logs, etc.
+    system("edge-core-factory-reset");
+    
     return true;
 }
 


### PR DESCRIPTION
# Mbed Edge pull request

## Description

Call a script in the PATH of edge-core when the user executes /3/0/5 - factory reset.  This will give system integrators a hook to clean up logs and other customer-specific data.

## Test instructions

1. Place a script in the PATH named edge-core-factory-reset
2. Execute /3/0/5 on Pelion portal
3. See that the script runs

## Check list

### API change(s)

 - [ ] Not applicable.
 - [x] API is backwards compatible.  If no script is found, this does nothing.
 - [ ] API documentation is updated.

### Example applications updated

 - [ ] Not applicable.
 

