### PR TITLE
fix calculation of remaining buffer size when calling update scripts

### DIFF
--- a/lib/mbed-cloud-client/update-client-hub/modules/pal-linux/source/arm_uc_pal_linux_implementation_internal.c
+++ b/lib/mbed-cloud-client/update-client-hub/modules/pal-linux/source/arm_uc_pal_linux_implementation_internal.c
@@ -175,7 +175,7 @@ static bool arm_uc_pal_linux_internal_command(arm_ucp_worker_t *parameters,
             }
 
             /* update remaining */
-            remaining = ARM_UC_MAXIMUM_FILE_AND_PATH_LENGTH - length;
+            remaining = command_length - length;
 
             /* check validity */
             valid = ((result.error == ERR_NONE) && (remaining > 0));
@@ -203,7 +203,7 @@ static bool arm_uc_pal_linux_internal_command(arm_ucp_worker_t *parameters,
             }
 
             /* update remaining */
-            remaining = ARM_UC_MAXIMUM_FILE_AND_PATH_LENGTH - length;
+            remaining = command_length - length;
 
             /* check validity */
             valid = ((result.error == ERR_NONE) && (remaining > 0));
@@ -218,7 +218,7 @@ static bool arm_uc_pal_linux_internal_command(arm_ucp_worker_t *parameters,
                                *arm_uc_location);
 
             /* update remaining */
-            remaining = ARM_UC_MAXIMUM_FILE_AND_PATH_LENGTH - length;
+            remaining = command_length - length;
 
             /* check validity */
             valid = (remaining > 0);
@@ -233,7 +233,7 @@ static bool arm_uc_pal_linux_internal_command(arm_ucp_worker_t *parameters,
                                arm_uc_offset);
 
             /* update remaining */
-            remaining = ARM_UC_MAXIMUM_FILE_AND_PATH_LENGTH - length;
+            remaining = command_length - length;
 
             /* check validity */
             valid = (remaining > 0);
@@ -249,7 +249,7 @@ static bool arm_uc_pal_linux_internal_command(arm_ucp_worker_t *parameters,
                                    arm_uc_buffer->size_max);
 
                 /* update remaining */
-                remaining = ARM_UC_MAXIMUM_FILE_AND_PATH_LENGTH - length;
+                remaining = command_length - length;
 
                 /* check validity */
                 valid = (remaining > 0);


### PR DESCRIPTION
the buffer used to hold the full shell command to call the upgrade
scripts during FOTA is of length ARM_UC_MAXIMUM_COMMAND_LENGTH
(currently 256), but the caluclation for space remaining after printing
a file path to the buffer was incorrectly using a different value,
ARM_UC_MAXIMUM_FILE_AND_PATH_LENGTH (currently 128) as the buffer
length, causing the function to fail incorrectly.

the fix is to use the buffer length passed into the function rather
than using a different hardcoded #define.

# Mbed Edge pull request

`
Bug fix during FOTA.  See commit message.
`

## Description

`See commit message.`

## Test instructions

`Provide a path name longer than 128 characters but less than 256 characters to the arm_update_*.sh scripts.  For example, here: https://github.com/ARMmbed/mbed-edge/blob/443d7d9d0092362fc705968b5b95cd8772b434b8/lib/mbed-cloud-client/update-client-hub/modules/pal-linux/source/arm_uc_pal_linux_generic.c#L112`

`Configure a long path name as specified above and initiate a FOTA.  Observe the FOTA fail at runtime because the path name is too long.`

## Check list

### API change(s)

 - [ ] Not applicable.
 - [ ] API is backwards compatible.
 - [ ] API documentation is updated.

### Example applications updated

 - [ ] Not applicable.
 

